### PR TITLE
Fixed Documentation Link

### DIFF
--- a/Libraries.lua
+++ b/Libraries.lua
@@ -255,6 +255,6 @@ return {
 	Aurora = {
 		URL = "evaera/Aurora/tree/master/lib";
 		Description = "Aurora is a library that can manage status effects (known as \"Auras\") in your Roblox game.";
-		Documentation = "https://github.com/evaera/Cmdr/blob/master/README.md";
+		Documentation = "https://github.com/evaera/Aurora/blob/master/README.md";
 	};
 };


### PR DESCRIPTION
Aurora had a wrong Documentation Link, it redirected to the docs of Cmdr, so I changed it to the Aurora docs